### PR TITLE
Add most recent translation to index, add bootstrap

### DIFF
--- a/web-app/app.py
+++ b/web-app/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, jsonify
 from db import translations
 
 app = Flask(__name__)
@@ -13,6 +13,12 @@ def history():
     history_data = list(cursor)
     cursor.close()
     return render_template("history.html", history=history_data)
+
+@app.route("/translation")
+def translation():
+    translation = translations.find_one(sort=[('_id', -1)])
+    translation.pop("_id") # Pop _id field because jsonify has no clue what to do with it.
+    return jsonify(translation)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=80)

--- a/web-app/templates/history.html
+++ b/web-app/templates/history.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Translator - History</title>
+    
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
 </head>
 <body>
     <table>

--- a/web-app/templates/index.html
+++ b/web-app/templates/index.html
@@ -1,1 +1,33 @@
-Last Translated Message: (last translated message will go here)
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Translator</title>
+    
+    <script>
+        function getTranslation() {
+            fetch('/translation')
+                .then((response) => {
+                    // Get most recent translation information.
+                    return response.json();
+                })
+                .then((translation) => {
+                    // Put most recent translation information into "lastmessage" element.
+                    let translationContainer = document.getElementById("lastmessage");
+                    translationContainer.innerHTML = translation["outputText"];
+                });
+        }
+    
+        // Get data on page load.
+        getTranslation();
+    
+        // Update data every second.
+        setInterval(getTranslation, 1000);
+    </script>
+</head>
+<body>
+    <span id="lastmessage"></span>
+</body>
+</html>

--- a/web-app/templates/index.html
+++ b/web-app/templates/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Translator</title>
-    
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+
     <script>
         function getTranslation() {
             fetch('/translation')


### PR DESCRIPTION
I created an API endpoint at `/translation` that returns the most recent translation in JSON. Then I used JavaScript to load that information once on page load, and then every second after. I think this is as good a way as any to handle the updating, but feel free to let me know if you can think of something better.

I also added the bootstrap CSS stylesheet to both of our templates, as we discussed.