### PR TITLE
tests: reconfigured tests for more accurate coverage

### DIFF
--- a/web-app/flaskr/db.py
+++ b/web-app/flaskr/db.py
@@ -5,9 +5,12 @@ def get_translations_collection(client):
     db = client.translator
     return db.translations
 
-if __name__ == "__main__":
-    # import sample data into the database
-    client = pymongo.MongoClient('mongodb://localhost:27017')
-    with open('sample_data.json', 'r', encoding='utf-8') as f:
+def insert_sample_data(client, fn='sample_data.json'):
+    with open(fn, 'r', encoding='utf-8') as f:
         data = json.load(f)
         get_translations_collection(client).insert_many(data)
+
+if __name__ == "__main__":
+    # import sample data into the database
+    insert_sample_data(pymongo.MongoClient('mongodb://localhost:27017'))
+    

--- a/web-app/tests/sample_data.json
+++ b/web-app/tests/sample_data.json
@@ -1,0 +1,27 @@
+[
+    {
+        "inputLanguage": "de",
+        "inputText": "Guten tag.",
+        "outputText": "Good morning."
+    },
+    {
+        "inputLanguage": "es",
+        "inputText": "Mucho gusto.",
+        "outputText": "Nice to meet you."
+    },
+    {
+        "inputLanguage": "fr",
+        "inputText": "Pardon, excusez-moi.",
+        "outputText": "Pardon, excuse me."
+    },
+    {
+        "inputLanguage": "ja",
+        "inputText": "ごめんなさい。",
+        "outputText": "I am sorry."
+    },
+    {
+        "inputLanguage": "zh",
+        "inputText": "不用谢。",
+        "outputText": "You're welcome."
+    }
+]

--- a/web-app/tests/test.py
+++ b/web-app/tests/test.py
@@ -1,80 +1,93 @@
 from flaskr import create_app
-from flaskr.db import get_translations_collection
+from flaskr.db import get_translations_collection, insert_sample_data
 import pytest
 import mongomock
+import os
 
-@pytest.fixture
-def mongo_client():
-    mock_client = mongomock.MongoClient('mongodb://localhost:27017')
-    mock_translations_collection = mock_client.translator.translations
-    mock_translations_collection.insert_one({
-        "inputLanguage": "de",
-        "inputText": "Guten tag.",
-        "outputText": "Good morning."
-    })
-    mock_translations_collection.insert_one({
-        "inputLanguage": "es",
-        "inputText": "Mucho gusto.",
-        "outputText": "Nice to meet you."
-    })
-    mock_translations_collection.insert_one({
-        "inputLanguage": "fr",
-        "inputText": "Pardon, excusez-moi.",
-        "outputText": "Pardon, excuse me."
-    })
-    mock_translations_collection.insert_one({
-        "inputLanguage": "ja",
-        "inputText": "ごめんなさい。",
-        "outputText": "I am sorry."
-    })
-    yield mock_client
-    mock_translations_collection.drop()
+class Tests: # pragma: no cover
+    @pytest.fixture
+    def mongo_client(self):
+        mock_client = mongomock.MongoClient('mongodb://localhost:27017')
+        mock_translations_collection = mock_client.translator.translations
+        mock_translations_collection.insert_one({
+            "inputLanguage": "de",
+            "inputText": "Guten tag.",
+            "outputText": "Good morning."
+        })
+        mock_translations_collection.insert_one({
+            "inputLanguage": "es",
+            "inputText": "Mucho gusto.",
+            "outputText": "Nice to meet you."
+        })
+        mock_translations_collection.insert_one({
+            "inputLanguage": "fr",
+            "inputText": "Pardon, excusez-moi.",
+            "outputText": "Pardon, excuse me."
+        })
+        mock_translations_collection.insert_one({
+            "inputLanguage": "ja",
+            "inputText": "ごめんなさい。",
+            "outputText": "I am sorry."
+        })
+        yield mock_client
+        mock_translations_collection.drop()
 
-@pytest.fixture
-def app(mongo_client):
-    app = create_app({
-        "TESTING": True,
-        "MONGO_CLIENT": mongo_client
-    })
-    return app
+    @pytest.fixture
+    def app(self, mongo_client):
+        app = create_app({
+            "TESTING": True,
+            "MONGO_CLIENT": mongo_client
+        })
+        return app
 
-@pytest.fixture
-def client(app):
-    return app.test_client()
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
 
-def test_get_translations_collection(mongo_client):
-    translations_collection = get_translations_collection(mongo_client)
-    input_languages = ["de", "es", "fr", "ja"]
-    for input_language in input_languages:
-        assert translations_collection.find_one({"inputLanguage": input_language}) is not None
-    assert translations_collection.find_one({"inputLanguage": "zh"}) is None
+    def test_insert_sample_data(self, mongo_client): 
+        mongo_client.translator.translations.drop()
+        assert get_translations_collection(mongo_client).find_one({"inputLanguage":"de"}) is None
 
-# TODO: testing the homepage may prove difficult because of the javascript in it
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        sample_data_path = os.path.join(dir_path, './sample_data.json')
+        insert_sample_data(mongo_client, sample_data_path)
 
-def test_get_history(client):
-    response = client.get("/history")
-    assert b"<td>de</td>" in response.data
-    assert b"<td>es</td>" in response.data
-    assert b"<td>fr</td>" in response.data
-    assert b"<td>ja</td>" in response.data
-    assert b"<td>zh</td>" not in response.data
+        assert get_translations_collection(mongo_client).find_one({"inputLanguage":"de"}) is not None
+        
 
-def test_translation_endpoint(client):
-    response = client.get("/translation")
-    assert b'"inputLanguage":"ja"' in response.data
-    assert b'"inputLanguage":"fr"' not in response.data
+    def test_get_translations_collection(self, mongo_client):
+        translations_collection = get_translations_collection(mongo_client)
+        input_languages = ["de", "es", "fr", "ja"]
+        for input_language in input_languages:
+            assert translations_collection.find_one({"inputLanguage": input_language}) is not None
+        assert translations_collection.find_one({"inputLanguage": "zh"}) is None
 
-def test_translation_endpoint_update(client, mongo_client):
-    response1 = client.get("/translation")
-    assert b'"inputLanguage":"ja"' in response1.data
-    assert b'"inputLanguage":"zh"' not in response1.data
+    # TODO: testing the homepage may prove difficult because of the javascript in it
 
-    mongo_client.translator.translations.insert_one({
-        "inputLanguage": "zh",
-        "inputText": "不用谢。",
-        "outputText": "You're welcome."
-    })
+    def test_get_history(self, client):
+        response = client.get("/history")
+        assert b"<td>de</td>" in response.data
+        assert b"<td>es</td>" in response.data
+        assert b"<td>fr</td>" in response.data
+        assert b"<td>ja</td>" in response.data
+        assert b"<td>zh</td>" not in response.data
 
-    response2 = client.get("/translation")
-    assert b'"inputLanguage":"zh"' in response2.data
-    assert b'"inputLanguage":"ja"' not in response2.data
+    def test_translation_endpoint(self, client):
+        response = client.get("/translation")
+        assert b'"inputLanguage":"ja"' in response.data
+        assert b'"inputLanguage":"fr"' not in response.data
+
+    def test_translation_endpoint_update(self, client, mongo_client):
+        response1 = client.get("/translation")
+        assert b'"inputLanguage":"ja"' in response1.data
+        assert b'"inputLanguage":"zh"' not in response1.data
+
+        mongo_client.translator.translations.insert_one({
+            "inputLanguage": "zh",
+            "inputText": "不用谢。",
+            "outputText": "You're welcome."
+        })
+
+        response2 = client.get("/translation")
+        assert b'"inputLanguage":"zh"' in response2.data
+        assert b'"inputLanguage":"ja"' not in response2.data


### PR DESCRIPTION
Made the changes we talked about from the standup this morning.

```
Name                 Stmts   Miss  Cover
----------------------------------------
flaskr\__init__.py      23      2    91%
flaskr\db.py            11      1    91%
----------------------------------------
TOTAL                   34      3    91%
```

I made it so that the test suite isn't covered in the code report, but the file at large still is (which includes the import lines). Turns out if we really want to remove the tests from code coverage, we should run 
```
coverage report --omit .\tests\*.py
```