### PR TITLE
fix: add a ui response to when the db is empty

### DIFF
--- a/web-app/flaskr/__init__.py
+++ b/web-app/flaskr/__init__.py
@@ -26,7 +26,6 @@ def create_app(test_config=None):
     @app.route("/translation")
     def translation():
         translation = get_translations_collection(app.config['MONGO_CLIENT']).find_one(sort=[('_id', -1)])
-        print(translation)
         if (translation == None):
             return jsonify({})
         translation.pop("_id") # Pop _id field because jsonify has no clue what to do with it.

--- a/web-app/flaskr/__init__.py
+++ b/web-app/flaskr/__init__.py
@@ -26,6 +26,9 @@ def create_app(test_config=None):
     @app.route("/translation")
     def translation():
         translation = get_translations_collection(app.config['MONGO_CLIENT']).find_one(sort=[('_id', -1)])
+        print(translation)
+        if (translation == None):
+            return jsonify({})
         translation.pop("_id") # Pop _id field because jsonify has no clue what to do with it.
         return jsonify(translation)
 

--- a/web-app/flaskr/templates/index.html
+++ b/web-app/flaskr/templates/index.html
@@ -27,6 +27,11 @@
                 })
                 .then((translation) => {
                     // Put most recent translation information into "lastmessage" element.
+                    if (translation.outputText == null) {
+                        document.querySelector("#outputText").textContent = "<No translations available>";
+                        document.querySelector("#debugInfo").textContent = "";
+                        return;
+                    }
                     document.getElementById("outputText").innerHTML = translation["outputText"];
                     let debug = "<br><b>Input Language: </b>" + translation["inputLanguage"] + ". <b>Input Text: </b>" + translation["inputText"] + ".";
                     document.getElementById("debugInfo").innerHTML = debug;

--- a/web-app/tests/test.py
+++ b/web-app/tests/test.py
@@ -62,7 +62,10 @@ class Tests: # pragma: no cover
             assert translations_collection.find_one({"inputLanguage": input_language}) is not None
         assert translations_collection.find_one({"inputLanguage": "zh"}) is None
 
-    # TODO: testing the homepage may prove difficult because of the javascript in it
+    def test_get_empty_collection(self, mongo_client, client):
+        mongo_client.translator.translations.drop()
+        response = client.get("/translation")
+        assert b"{}" in response.data
 
     def test_get_history(self, client):
         response = client.get("/history")


### PR DESCRIPTION
Right now, when the db is empty, the `/translation` endpoint sends a 500. This PR fixes it.