### PR TITLE
feat: add a display for output language

### DIFF
--- a/web-app/flaskr/__init__.py
+++ b/web-app/flaskr/__init__.py
@@ -23,6 +23,11 @@ def create_app(test_config=None):
         cursor = get_translations_collection(app.config['MONGO_CLIENT']).find()
         history_data = list(cursor)
         cursor.close()
+
+        for translation in history_data:
+            if ('outputLanguage' not in translation.keys()):
+                translation['outputLanguage'] = 'en'
+
         return render_template("history.html", history=history_data)
 
     @app.route("/translation")
@@ -31,6 +36,10 @@ def create_app(test_config=None):
         if (translation == None):
             return jsonify({})
         translation.pop("_id") # Pop _id field because jsonify has no clue what to do with it.
+        
+        # check if translation has an outputLanguage field for backward compatibility
+        if ('outputLanguage' not in translation.keys()):
+            translation['outputLanguage'] = 'en'
         return jsonify(translation)
 
     return app

--- a/web-app/flaskr/sample_data.json
+++ b/web-app/flaskr/sample_data.json
@@ -2,26 +2,31 @@
     {
         "inputLanguage": "de",
         "inputText": "Guten tag.",
-        "outputText": "Good morning."
+        "outputText": "Good morning.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "es",
         "inputText": "Mucho gusto.",
-        "outputText": "Nice to meet you."
+        "outputText": "Nice to meet you.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "fr",
         "inputText": "Pardon, excusez-moi.",
-        "outputText": "Pardon, excuse me."
+        "outputText": "Pardon, excuse me.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "ja",
         "inputText": "ごめんなさい。",
-        "outputText": "I am sorry."
+        "outputText": "I am sorry.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "zh",
         "inputText": "不用谢。",
-        "outputText": "You're welcome."
+        "outputText": "You're welcome.",
+        "outputLanguage": "en"
     }
 ]

--- a/web-app/flaskr/templates/history.html
+++ b/web-app/flaskr/templates/history.html
@@ -21,6 +21,7 @@
                         <th scope="col">Input Language</th>
                         <th scope="col">Input Text</th>
                         <th scope="col">Output Text</th>
+                        <th scope="col">Output Language</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -29,6 +30,7 @@
                         <td>{{ translation.inputLanguage }}</td>
                         <td>{{ translation.inputText }}</td>
                         <td>{{ translation.outputText }}</td>
+                        <td>{{ translation.outputLanguage }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/web-app/flaskr/templates/index.html
+++ b/web-app/flaskr/templates/index.html
@@ -33,7 +33,7 @@
                         return;
                     }
                     document.getElementById("outputText").innerHTML = translation["outputText"];
-                    let debug = "<br><b>Input Language: </b>" + translation["inputLanguage"] + ". <b>Input Text: </b>" + translation["inputText"] + ".";
+                    let debug = "<br><b>Input Language: </b>" + translation["inputLanguage"] + ". <b>Input Text: </b>" + translation["inputText"] + ".<br><b>Output Language: </b>" + translation["outputLanguage"] + ".";
                     document.getElementById("debugInfo").innerHTML = debug;
                 });
         }

--- a/web-app/tests/sample_data.json
+++ b/web-app/tests/sample_data.json
@@ -2,26 +2,31 @@
     {
         "inputLanguage": "de",
         "inputText": "Guten tag.",
-        "outputText": "Good morning."
+        "outputText": "Good morning.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "es",
         "inputText": "Mucho gusto.",
-        "outputText": "Nice to meet you."
+        "outputText": "Nice to meet you.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "fr",
         "inputText": "Pardon, excusez-moi.",
-        "outputText": "Pardon, excuse me."
+        "outputText": "Pardon, excuse me.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "ja",
         "inputText": "ごめんなさい。",
-        "outputText": "I am sorry."
+        "outputText": "I am sorry.",
+        "outputLanguage": "en"
     },
     {
         "inputLanguage": "zh",
         "inputText": "不用谢。",
-        "outputText": "You're welcome."
+        "outputText": "You're welcome.",
+        "outputLanguage": "en"
     }
 ]

--- a/web-app/tests/test.py
+++ b/web-app/tests/test.py
@@ -27,7 +27,8 @@ class Tests: # pragma: no cover
         mock_translations_collection.insert_one({
             "inputLanguage": "ja",
             "inputText": "ごめんなさい。",
-            "outputText": "I am sorry."
+            "outputText": "I am sorry.",
+            "outputLanguage": "en"
         })
         yield mock_client
         mock_translations_collection.drop()


### PR DESCRIPTION
Adds a display to the frontend that includes the output language.

Change is backwards compatible for database entries translated to english that do not have an output language field.

![image](https://user-images.githubusercontent.com/69036416/205546100-81c527aa-b703-4ba3-9a9a-3ff60991735a.png)

![image](https://user-images.githubusercontent.com/69036416/205546119-0c0c3e8b-aa3c-4fa4-98a6-a6c6afb2509b.png)
